### PR TITLE
[fix-10][epub]ImportError: libQt5Core.so.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y --no-install-recommends procps build-essential ca-certificates openssl openssh-client git bzip2 curl vim yarn && \
     apt-get clean && \
+    strip --remove-section=.note.ABI-tag /usr/lib/x86_64-linux-gnu/libQt5Core.so.5 && \
     rm -rf /var/lib/apt/lists/*
 
 # Install Node.js


### PR DESCRIPTION
close #10 

fix ImportError: libQt5Core.so.5

Reference:
https://askubuntu.com/questions/1034313/ubuntu-18-4-libqt5core-so-5-cannot-open-shared-object-file-no-such-file-or-dir